### PR TITLE
Correction to introduction

### DIFF
--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -9,7 +9,7 @@ In most cases, the battery comes in a **pack**, which consists of multiple **mod
 
 As described in chapter ["Battery"](battery.md), different cells have different minimum and maximum voltage levels as well as different phases while charging/discharging.
 The BMS is responsible to measure the voltage, current and temperature and calculate the state of charge (SOC) of the cells are in order to apply the correct current or voltage.
-It will optimise the charging rate and determine when to stop charging/discharging. 
+It will optimise the charging rate and determine when to stop charging/discharging.
 
 To disconnect the battery from the load/charger, different types of switches can be used. For low current systems, a MOSFET switch is often easiest to use, while a mechanical or solid state relais can be necessary to switch higher voltages and currents.
 

--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -1,7 +1,7 @@
 # Battery Management System
 
 A Battery Management System (BMS) is an electronic circuit that can manage a rechargeable device. Like most electronics, accumulators are limited in the voltage and current they can handle. While some are quite robust in terms of e.g. overvoltage or deep-discharge, it is vital especially for Li-on batteries, to monitor charge, discharge and charge cycles to ensure a long lifetime.
-In most cases, the battery comes in a **pack**, which consists of multiple **modules**, which each again consists of multiple **cells**. A single cell is the atomic unit of a battery and comes in different shapes ([1]). The cylindrical cell is most used in consumer electronics, as they are easy to connect and mechanically robust. In applications with higher energy demand, pouch cells are more common. Pouch cells need to be packed into modules, which includes a frame, sensors and sometimes features for cooling. Multiple modules are than stacked into a pack, which includes the BMS, cooling, fuses and necessary wiring amongst other components ([1]).
+In most cases, the battery comes in a **pack**, which consists of multiple **modules**, which each again consists of multiple **cells**. A single cell is the atomic unit of a battery and comes in different shapes ([1]). The pouch and prismatic cell shapes are most used in consumer electronics (mobile phones, laptops). In applications with higher energy demand, prismatic, cylindrical and pouch shaped cells are common. Pouch cells need to be packed into modules, which includes a frame, sensors and sometimes features for cooling. Multiple modules are than stacked into a pack, which includes the BMS, cooling, fuses and necessary wiring amongst other components ([1]).
 
 ## Main Functions
 
@@ -9,7 +9,7 @@ In most cases, the battery comes in a **pack**, which consists of multiple **mod
 
 As described in chapter ["Battery"](battery.md), different cells have different minimum and maximum voltage levels as well as different phases while charging/discharging.
 The BMS is responsible to measure the voltage, current and temperature and calculate the state of charge (SOC) of the cells are in order to apply the correct current or voltage.
-It will optimise the charging rate and determine when to stop charging/discharging.
+It will optimise the charging rate and determine when to stop charging/discharging. 
 
 To disconnect the battery from the load/charger, different types of switches can be used. For low current systems, a MOSFET switch is often easiest to use, while a mechanical or solid state relais can be necessary to switch higher voltages and currents.
 


### PR DESCRIPTION
As I am informed pouch and prismatic cells are most used in consumer electronics nowadays. To some extend there are cylindrical cells (front bike light, power banks, eBikes). Most used cathode chemistry should be NMC. Fairphone3 comes with exchangeable LFP battery. 

Electric vehicles (High Energy) generally use all 3 kinds of shapes:
-**pouch** cells are used by Nissan Leaf (NMC)  (see [1] p.6).  (48Modules with 4Cells)
-**cylindrical** cells with form factor 18650, 2170 (NCA) and latest 4680 (NCMA,NCA) are used by Tesla.  Example is Model 3 50kwh: 4Modules formed of 23 or 25 bricks in series, a brick containing 31 cells in parallel (total of 2976 cells).
-**prismatic**  cells are used by BYD Blade battery pack (LFP) and BMW i3 (NMC) (https://pubs.rsc.org/en/content/articlepdf/2020/gc/d0gc02745f?page=search p. 7589) 
CATL, SVOLT and BYD are building cell to package (CTP) batteries. An example is the 65 kWh BYD Blade Battery consisting of 101 cells (3,2V) in series with 202Ah each. 

In resume, for high energy one can not declare a dominant shape, for consumer electronics it depends on the definition of that category. 

In the future solid state Lion batteries (SSB) might become mass production ready, till now form factors (shapes) of those are not clear to me.