### PR TITLE
Correction of Balancing

### DIFF
--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -24,7 +24,7 @@ In order to keep the battery in a safe operational state, the thermal managmenen
 
 To optimize performance and lifetime of battery packs, balancing is used to distribute load and prevent localized over- or under-charging of cells. Since cells differ slightly in capacity depending on the quality of the manufacturing process and used materials or by cell-aging, cells connected in series can show different voltages. To normalize the SOC for each cell, a BMS can either actively transfer energy from higher charged cells to those with lower SOC or passivly, mostly by wasting energy from cells with 100% SOC until every cell is fully charged.
 
-Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is reponsible for dis-/connecting the resistor in parallel to the cell which has higher, thus excessive charge in comparsions to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficieny.
+Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is reponsible for dis-/connecting the resistor in parallel to the cell which has higher voltage, thus excessive charge in comparsions to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficieny.
 
 ![image](https://user-images.githubusercontent.com/13488510/122396568-660bb300-cf78-11eb-8798-1d3904f9fe4d.png)
 

--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -24,7 +24,7 @@ In order to keep the battery in a safe operational state, the thermal managmenen
 
 To optimize performance and lifetime of battery packs, balancing is used to distribute load and prevent localized over- or under-charging of cells. Since cells differ slightly in capacity depending on the quality of the manufacturing process and used materials or by cell-aging, cells connected in series can show different voltages. To normalize the SOC for each cell, a BMS can either actively transfer energy from higher charged cells to those with lower SOC or passivly, mostly by wasting energy from cells with 100% SOC until every cell is fully charged.
 
-Passive balancing can be done by converting excessive charge to heat using a resistor. The resistor is connected in parallel to the cell and switched on with a transistor for the cells with higher voltage, thus excessive charge in comparisons to the other cells in series. Passive balancing slightly increases the thermal energy dissipated by the pack and decreases the overall efficiency.
+Passive balancing can be done by converting excessive charge to heat using a resistor. The resistor is connected in parallel to the cell and switched on with a transistor for the cells with higher voltage, thus having excessive charge in comparisons to the other cells in series. Passive balancing slightly increases the thermal energy dissipated by the pack and decreases the overall efficiency.
 
 Active balancing aims to distribute the energy better while charging and discharging, but need much more circuitry.
 

--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -24,7 +24,7 @@ In order to keep the battery in a safe operational state, the thermal managmenen
 
 To optimize performance and lifetime of battery packs, balancing is used to distribute load and prevent localized over- or under-charging of cells. Since cells differ slightly in capacity depending on the quality of the manufacturing process and used materials or by cell-aging, cells connected in series can show different voltages. To normalize the SOC for each cell, a BMS can either actively transfer energy from higher charged cells to those with lower SOC or passivly, mostly by wasting energy from cells with 100% SOC until every cell is fully charged.
 
-Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is reponsible for dis-/connecting the resistor in parallel to the cell which has higher voltage, thus excessive charge in comparsions to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficieny.
+Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is responsible for dis-/connecting the resistor in parallel to the cell which has higher voltage, thus excessive charge in comparisons to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficiency.
 
 ![image](https://user-images.githubusercontent.com/13488510/122396568-660bb300-cf78-11eb-8798-1d3904f9fe4d.png)
 

--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -24,7 +24,9 @@ In order to keep the battery in a safe operational state, the thermal managmenen
 
 To optimize performance and lifetime of battery packs, balancing is used to distribute load and prevent localized over- or under-charging of cells. Since cells differ slightly in capacity depending on the quality of the manufacturing process and used materials or by cell-aging, cells connected in series can show different voltages. To normalize the SOC for each cell, a BMS can either actively transfer energy from higher charged cells to those with lower SOC or passivly, mostly by wasting energy from cells with 100% SOC until every cell is fully charged.
 
-Passive balancing can be done by bleeding energy to ground through a resistor and a transistor or with a resistor parallel to the cell which acts like a small consumer. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficieny.
+Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is reponsible for dis-/connecting the resistor in parallel to the cell which has higher, thus excessive charge in comparsions to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficieny.
+
+![image](https://user-images.githubusercontent.com/13488510/122396568-660bb300-cf78-11eb-8798-1d3904f9fe4d.png)
 
 Active balancing aims to distribute the energy better while charging and discharging, but need much more circuitry.
 

--- a/docs/system/bms.md
+++ b/docs/system/bms.md
@@ -24,9 +24,7 @@ In order to keep the battery in a safe operational state, the thermal managmenen
 
 To optimize performance and lifetime of battery packs, balancing is used to distribute load and prevent localized over- or under-charging of cells. Since cells differ slightly in capacity depending on the quality of the manufacturing process and used materials or by cell-aging, cells connected in series can show different voltages. To normalize the SOC for each cell, a BMS can either actively transfer energy from higher charged cells to those with lower SOC or passivly, mostly by wasting energy from cells with 100% SOC until every cell is fully charged.
 
-Passive balancing can be done by converting excessive charge to heat over a resistor (R20). A transistor (Q5) is responsible for dis-/connecting the resistor in parallel to the cell which has higher voltage, thus excessive charge in comparisons to the other cells in series. Passive balancing increases the thermal energy dissipated by the pack and decreases the overall efficiency.
-
-![image](https://user-images.githubusercontent.com/13488510/122396568-660bb300-cf78-11eb-8798-1d3904f9fe4d.png)
+Passive balancing can be done by converting excessive charge to heat using a resistor. The resistor is connected in parallel to the cell and switched on with a transistor for the cells with higher voltage, thus excessive charge in comparisons to the other cells in series. Passive balancing slightly increases the thermal energy dissipated by the pack and decreases the overall efficiency.
 
 Active balancing aims to distribute the energy better while charging and discharging, but need much more circuitry.
 


### PR DESCRIPTION
Illustrated the statement with the circuit of https://github.com/LibreSolar/bms-15s80-sc/blob/master/LibreSolar_BMS48V_schematic.pdf
I haven't seen a circuit bleeding current to common ground (0V reference), thus I question that even exists, as it would reduce the current charging the other cells? 

TODO: the image should be uploaded to the repo and should be .svg, adding some arrows [1] showing the current flow and maybe the chip switching the MOSFET would be a good addition. Nice to have would be  autogeneration of the illustration whenever the circuit changes. A link to the bms-15s80-sc could be added as well. 

[1] Resource: https://www.avdweb.nl/solar-bike/electronics/bms