### PR TITLE
Fix broken 'Edit this page on GitHub!' links.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -135,7 +135,7 @@ module.exports = {
     // if your docs are not at the root of the repo:
     docsDir: 'docs',
     // if your docs are in a specific branch (defaults to 'master'):
-    docsBranch: 'master',
+    docsBranch: 'main',
     // defaults to false, set to true to enable
     editLinks: true,
     // custom text for edit link. Defaults to "Edit this page"


### PR DESCRIPTION
Resource: https://vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links
Or https://github.com/LibreSolar/libresolar.github.io/blob/main/docs/.vuepress/config.ts